### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip install --upgrade pip
   - pip install check-manifest coveralls pep257
   - pip install pytest pytest-pep8 pytest-cov pytest-cache
-  - pip install -e .[docs]
+  - pip install -e .[docs,tests]
 
 script:
   - "check-manifest --ignore .travis-\\*-requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,13 @@ before_install:
   - sudo apt-get -qqy update
 
 install:
-  - pip install --upgrade pip  --use-mirrors
-  - pip install coveralls pep257 --use-mirrors
-  - pip install pytest pytest-pep8 pytest-cov pytest-cache --use-mirrors
+  - pip install --upgrade pip
+  - pip install check-manifest coveralls pep257
+  - pip install pytest pytest-pep8 pytest-cov pytest-cache
   - pip install -e .[docs]
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - sphinx-build -qnNW docs docs/_build/html
   - python setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # This file is part of Invenio-Client.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio-Client is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,14 +21,13 @@
 
 language: python
 
+sudo: false
+
 python:
   - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
-
-before_install:
-  - sudo apt-get -qqy update
 
 install:
   - pip install --upgrade pip

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,4 +20,4 @@
 # or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_client --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_client --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ with open(os.path.join('invenio_client', 'version.py'), 'rt') as f:
 
 tests_require = [
     'pytest-cache>=1.0',
-    'pytest-cov>=1.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.6.1',
-    'coverage'
+    'pytest>=2.8.0',
+    'coverage>=4.0.0'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
     ],
     extras_require={
         "docs": ["sphinx_rtd_theme"],
+        "tests": tests_require,
     },
     tests_require=tests_require,
     cmdclass={'test': PyTest},


### PR DESCRIPTION
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>