### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,10 +24,10 @@ Authors
 =======
 
 Invenio-Client is developed to connect to remote `Invenio
-<http://invenio-software.org>`_ digital library instances.
+<http://inveniosoftware.org>`_ digital library instances.
 
-Contact us at `info@invenio-software.org
-<mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org
+<mailto:info@inveniosoftware.org>`_.
 
 - Adrian-Tudor Panescu <adrian.tudor.panescu@cern.ch>
 - Alejandro Avilés <aavilesd@cern.ch>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -30,7 +30,7 @@ Documentation
 Good luck and thanks for using Invenio-Client.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-client

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@
     </p>
 
 Invenio-Client is a Python library permitting to connect to remote
-`Invenio <http://invenio-software.org>`_ digital library instances.
+`Invenio <http://inveniosoftware.org>`_ digital library instances.
 
 Contents
 --------
@@ -68,7 +68,7 @@ The easiest way is to use *invenio_client* directly with
 .. code-block:: python
 
     from invenio_client import InvenioConnector
-    demo = InvenioConnector("http://demo.invenio-software.org")
+    demo = InvenioConnector("http://demo.inveniosoftware.org")
 
     results = demo.search("higgs")
 

--- a/invenio_client/connector.py
+++ b/invenio_client/connector.py
@@ -28,7 +28,7 @@ Example of use:
 .. code-block:: python
 
     from invenio_client import InvenioConnector
-    demo = InvenioConnector("http://demo.invenio-software.org")
+    demo = InvenioConnector("http://demo.inveniosoftware.org")
 
     results = demo.search("higgs")
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     url="https://github.com/inveniosoftware/invenio-client",
     license='GPLv2',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description="Invenio-Client permits to connect to remote Invenio digital "
         "library instances.",
     long_description=__doc__,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,8 +29,8 @@ from unittest import TestCase
 
 from invenio_client import InvenioConnector, InvenioConnectorAuthError
 
-CFG_SITE_URL = 'http://demo.invenio-software.org'
-CFG_SITE_SECURE_URL = 'https://demo.invenio-software.org'
+CFG_SITE_URL = 'http://demo.inveniosoftware.org'
+CFG_SITE_SECURE_URL = 'https://demo.inveniosoftware.org'
 
 
 class InvenioConnectorTest(TestCase):
@@ -43,7 +43,7 @@ class InvenioConnectorTest(TestCase):
         result = server.search(p='ellis', of='id')
         self.assertTrue(len(list(result)) > 0,
                         'did not get remote search results from '
-                        'http://demo.invenio-software.org')
+                        'http://demo.inveniosoftware.org')
 
     def test_search_collections(self):
         """InvenioConnector - collection search"""


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>